### PR TITLE
Support to parsing chinese characters in account

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -88,7 +88,7 @@ module.exports = grammar({
                     repeat1(
                         seq(
                             ":",
-                            /[\p{Lu}\p{N}][\p{L}\p{N}\-]*/,
+                            /[\p{Lu}\p{N}\u4e00-\u9fff][\p{L}\p{N}\u4e00-\u9fff\-]*/,
                         ),
                     ),
                 ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -237,7 +237,7 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[\\p{Lu}\\p{N}][\\p{L}\\p{N}\\-]*"
+                  "value": "[\\p{Lu}\\p{N}\\u4e00-\\u9fff][\\p{L}\\p{N}\\u4e00-\\u9fff\\-]*"
                 }
               ]
             }
@@ -2834,3 +2834,4 @@
     "_directive"
   ]
 }
+

--- a/test/corpus/chinese_characters.txt
+++ b/test/corpus/chinese_characters.txt
@@ -1,0 +1,25 @@
+===
+chinese characters in accounts
+===
+
+2010-01-01 * "payee" "narration"
+  Liabilities:Bank:工行:Credit:AMEX:1111                -89.00 CNY
+  Expenses:Restaurant
+
+---
+
+(file
+    (transaction
+        (date)
+        (txn)
+        (payee)
+        (narration)
+        (posting
+            (account)
+            (incomplete_amount
+            (unary_number_expr
+              (minus)
+              (number))
+            (currency)))
+        (posting
+          (account))))


### PR DESCRIPTION
As mentioned in https://github.com/beancount/beancount/issues/398 https://github.com/beancount/beancount/issues/423,
chinese characters are supported in beancount (at least in v3).

Because \p{L} does't include chinese characters in current tree-sitter-beancount environment, so I upated grammer to support chinese characters in Account.

Should we support chinese characters?