### PR TITLE
feat(rust): support compile to `wasm32-unknown-unknown` with feature wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,3 +328,15 @@ jobs:
         if: steps.scanner-changes.outputs.changed == 'true'
         timeout-minutes: 10
         run: tree-sitter fuzz --iterations 300
+
+  wasm32:
+    name: compile rust binding on wasm32
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+
+      - run: cargo build --target wasm32-unknown-unknown --no-default-features --features=wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,20 @@ categories = ["parsing", "text-editors"]
 repository = "https://github.com/polarmutex/tree-sitter-beancount"
 edition = "2018"
 license = "MIT"
-
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
+[features]
+default = ["std"]
+std = ["tree-sitter/std"]
+wasm = ["tree-sitter-language"]
+
 [dependencies]
-tree-sitter = "~0.26.3"
+tree-sitter = { version = "~0.26.3", default-features = false }
+tree-sitter-language = { version = "0.1.6", optional = true }
 
 [build-dependencies]
 cc = "1.2"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,41 +2,73 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
     c_config
+        .std("c11")
+        .include(src_dir)
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs")
+        .flag_if_supported("-Wno-incompatible-pointer-types")
+        .flag_if_supported("-Wno-unused-function")
+        .flag_if_supported("-Wno-unused-label")
         .flag_if_supported("-O");
+
     #[cfg(target_env = "msvc")]
-    c_config.flag("-utf-8");
+    c_config.flag_if_supported("/utf-8");
+
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        if std::env::var("CARGO_FEATURE_WASM").is_err() {
+            panic!("The `wasm` feature must be enabled to build for wasm32-unknown-unknown");
+        }
+
+        let Ok(wasm_headers) = std::env::var("DEP_TREE_SITTER_LANGUAGE_WASM_HEADERS") else {
+            panic!("Environment variable DEP_TREE_SITTER_LANGUAGE_WASM_HEADERS must be set by the language crate");
+        };
+
+        let Ok(wasm_src) =
+            std::env::var("DEP_TREE_SITTER_LANGUAGE_WASM_SRC").map(std::path::PathBuf::from)
+        else {
+            panic!("Environment variable DEP_TREE_SITTER_LANGUAGE_WASM_SRC must be set by the language crate");
+        };
+
+        c_config.include(&wasm_headers);
+        c_config.files([
+            wasm_src.join("stdio.c"),
+            wasm_src.join("stdlib.c"),
+            wasm_src.join("string.c"),
+        ]);
+    }
 
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-
-    c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
+    let scanner_path = src_dir.join("scanner.c");
+    if scanner_path.exists() {
+        c_config.file(&scanner_path);
+        println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    }
 
-    /*
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
+    c_config.compile("tree-sitter-beancount");
+
+    println!("cargo:rustc-check-cfg=cfg(with_highlights_query)");
+    if !"queries/highlights.scm".is_empty()
+        && std::path::Path::new("queries/highlights.scm").exists()
+    {
+        println!("cargo:rustc-cfg=with_highlights_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_injections_query)");
+    if !"queries/injections.scm".is_empty()
+        && std::path::Path::new("queries/injections.scm").exists()
+    {
+        println!("cargo:rustc-cfg=with_injections_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_locals_query)");
+    if !"queries/locals.scm".is_empty() && std::path::Path::new("queries/locals.scm").exists() {
+        println!("cargo:rustc-cfg=with_locals_query");
+    }
+    println!("cargo:rustc-check-cfg=cfg(with_tags_query)");
+    if !"queries/tags.scm".is_empty() && std::path::Path::new("queries/tags.scm").exists() {
+        println!("cargo:rustc-cfg=with_tags_query");
+    }
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -11,6 +11,10 @@
 #include <tree_sitter/parser.h>
 #include <wctype.h>
 
+#if !defined (UINT8_MAX)
+#define UINT8_MAX 255
+#endif
+
 // Utility macros
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
@@ -155,7 +159,7 @@ unsigned serialize(Scanner *scanner, char *buffer) {
     buffer[i++] = (char)indent_count;
 
     // Write indentation stack data (starting from index 1)
-    int iter = 1;
+    uint32_t iter = 1;
     for (; iter < scanner->indent_length_stack.length
            && i < TREE_SITTER_SERIALIZATION_BUFFER_SIZE;
          ++iter) {


### PR DESCRIPTION
with this patch, the downstream users will be able to use the crate in wasm32 target with this:

```
tree-sitter-beancount = { default-features = false, features = ['wasm'] }
```