### PR TITLE
fix: `tree-sitter.json` now obeys schema

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,13 +1,11 @@
 {
-  "version": "0.25.4",
-  "generator": {
-    "abi": 15
-  },
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
   "metadata": {
-    "name": "beancount",
-    "url": "https://github.com/polarmutex/tree-sitter-beancount",
     "description": "Tree-sitter grammar for Beancount",
-    "version": "2.4.1"
+    "version": "2.4.1",
+    "links": {
+      "repository": "https://github.com/polarmutex/tree-sitter-beancount"
+    }
   },
   "grammars": [
     {


### PR DESCRIPTION
See upstream schema:
<https://github.com/tree-sitter/tree-sitter/blob/v0.26.5/docs/src/assets/schemas/config.schema.json>. A number of these fields were invalid.